### PR TITLE
Paired functions, instead of just macro/endmacro

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,14 @@ A CMake file formatter, written in Typescript
 
 ## Current status
 
-This thing parses (and kinda prints) my silly little
-[cassette](http://github.com/kevinfrei/cassette) project's CMakeLists.txt files.
+This thing parses (and badly prints) my silly little
+[cassette](http://github.com/kevinfrei/cassette) project's CMakeLists.txt files,
+as well as **all 2000+** LLVM/Clang/LLDB/LLD CMake files which is, in my
+opinion, good enough to be useful. Basically, it will parse and correctly
+'round-trip' everything.
 
-It currently parses over 90% of the LLVM/Clang/LLDB CMake files which is, in my
-opinion, quite a lot. Next steps on the 'completeness' side of things is to
-drive this number up. I expect that LLVM's CMake build is one of the most
-complex in existence, but it's also a very **good** use of CMake, so it isn't
-necessarily going to have lots of weird stuff all over the place.
-
-I haven't yet started thinking about what a "pretty" CMake file would look like,
-but I'm approaching a point where I need to.
+Next step: Actually pretty-printing!
 
 ### TODO:
 
-- Increase LLVM's CMake tokenization/parsing/printing success rate.
 - Start making the printer actually print things nicely.

--- a/src/__tests__/llvm.test.ts
+++ b/src/__tests__/llvm.test.ts
@@ -8,7 +8,7 @@ import {
   printFullFile,
 } from './test-helpers';
 
-test('(FAILING): Try to process all the LLVM CMake files', async () => {
+test('Process all the LLVM CMake files [if the repo exists]', async () => {
   // If there's an LLVM repo one up from here, go ahead and read it's .cmake files
   const llvmPath = llvmRepoExists();
   if (isUndefined(llvmPath)) {
@@ -79,12 +79,17 @@ test('(FAILING): Try to process all the LLVM CMake files', async () => {
       100
     ).toFixed(2);
     const sortedFailures = failures.sort((a, b) => a.fileSize - b.fileSize);
-    const sortedPrintFailures = printFailures.sort((a, b) => a.fileSize - b.fileSize);
-    const pfailStr = printSuccess !== success ? `
+    const sortedPrintFailures = printFailures.sort(
+      (a, b) => a.fileSize - b.fileSize,
+    );
+    const pfailStr =
+      printSuccess !== success
+        ? `
 Print failures: ${printFailures.length} out of ${success} total
-==> ${sortedPrintFailures.map(f => `${f.path} [${f.fileSize} bytes]`).join('\n==> ')}` : '';
+==> ${sortedPrintFailures.map((f) => `${f.path} [${f.fileSize} bytes]`).join('\n==> ')}`
+        : '';
     throw new Error(`Failed to process files:
---> ${sortedFailures.map(f => `${f.path} [${f.fileSize} bytes]`).join('\n--> ')}
+--> ${sortedFailures.map((f) => `${f.path} [${f.fileSize} bytes]`).join('\n--> ')}
 Processed files: Failed ${failures.length} out of ${success + failures.length} total.
 Failure rate: ${failureRate}%${pfailStr}`);
   }

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { ParserTokenType } from '../parser';
-import { parseTestFile, parseString } from './test-helpers';
+import { parseString, parseTestFile } from './test-helpers';
 
 describe('Parser', () => {
   test('parses basic command', () => {
@@ -11,7 +11,7 @@ describe('Parser', () => {
   test('parses macros and conditionals', () => {
     const ast = parseTestFile('grammar.cmake');
     expect(
-      ast.statements.some((s) => s.type === ParserTokenType.MacroDefinition),
+      ast.statements.some((s) => s.type === ParserTokenType.PairedCall),
     ).toBeTrue();
     expect(
       ast.statements.some((s) => s.type === ParserTokenType.ConditionalBlock),

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -1,7 +1,6 @@
 // Tokenizer types
 
 import { isString, isUndefined } from '@freik/typechk';
-import { start } from 'repl';
 
 // This should be faster, but the strings make it more debuggable
 export enum NumberedTokenType {
@@ -63,7 +62,7 @@ export type TokenStream = {
   count: () => number;
   history: (num: number) => Token[];
   expect: (type: TokenType, value?: string) => Token;
-  expectIdentifier: () => string;
+  expectIdentifier: (val?: string) => string;
   expectOpenParen: () => boolean;
   expectCloseParen: () => boolean;
   /*
@@ -236,8 +235,11 @@ export function MakeTokenStream(input: string): TokenStream {
     );
   }
 
-  function expectIdentifier(): string {
-    return expect(TokenType.Identifier).value!;
+  function expectIdentifier(val?: string): string {
+    const token = isUndefined(val)
+      ? expect(TokenType.Identifier)
+      : expect(TokenType.Identifier, val);
+    return token.value!;
   }
 
   function MaybePush(curToken: string): string {


### PR DESCRIPTION
I also made the ArgList parser expect the surrounding parentheses.