### PR TITLE
Line breaking parenthesized arg groups now occurs as necessary

### DIFF
--- a/src/__tests__/inputs/cassette.cmake
+++ b/src/__tests__/inputs/cassette.cmake
@@ -32,7 +32,11 @@ else()
     OR
       (CMAKE_BUILD_WITH_INSTALL_NAME_DIR STREQUAL "DEBUGDIR")
     OR
-      (CMAKE_LINK_LIBRARY_USING_MODULES_SUPPORTED STREQUAL "LONG_STRING_TOO_LONG_TO_FIT_ON_A SINGLE_LINE")
+      (
+        CMAKE_LINK_LIBRARY_USING_MODULES_SUPPORTED
+        STREQUAL
+        "LONG_STRING_TOO_LONG_TO_FIT_ON_A SINGLE_LINE"
+      )
   )
     add_compile_options(-fsanitize=address,undefined -O0 -g)
     add_link_options(-fsanitize=address,undefined -O0 -g)


### PR DESCRIPTION
Got a little test in cassette.cmake to validate that it occurs.